### PR TITLE
[fix] github 프로필 링크 높이에 누락된 단위 추가

### DIFF
--- a/blog/package.json
+++ b/blog/package.json
@@ -14,7 +14,7 @@
     "start": "gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "deploy": "rimraf public && gatsby build --prefix-paths && gh-pages -d public"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-minimal-blog": "^2.7.3",
@@ -35,6 +35,7 @@
     "gatsby-transformer-yaml": "^2.9.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "rimraf": "3.0.2",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/blog/src/components/GithubProfileLink.tsx
+++ b/blog/src/components/GithubProfileLink.tsx
@@ -13,7 +13,7 @@ const GithubProfileLink = ({ to, ...props }: GithubProfileLinkProps) => {
       sx={{
         display: "flex",
         width: ["15px", "24px"],
-        height: ["15", "24px"],
+        height: ["15px", "24px"],
         cursor: "pointer",
       }}
       {...props}

--- a/blog/yarn.lock
+++ b/blog/yarn.lock
@@ -13479,17 +13479,17 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2, rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
팀 블로그 Author 컴포넌트에서 발생하는 오류를 수정합니다.

## 변경 사항
- iOS 크롬이나, 사파리에서는 Author 컴포넌트의 높이가 깨져서 나옵니다.
     ![image](https://user-images.githubusercontent.com/6239742/109626284-b276e280-7b83-11eb-8a17-b0d50343637a.png)
  - github 프로필 링크 높이가 `15`로 되던 것이 원인이었고, 뒤에 단위를 붙여줍니다.
- `deploy` 스크립트에서 `public` 폴더를 제거하게 합니다.
  - 이전에 빌드되었던 파일이 배포되지 않게 하는 것을 보장하게 합니다.